### PR TITLE
Joomla 3 changes, refine debugging and Group Map supports multiple Joomla group ids

### DIFF
--- a/crowd/crowd.php
+++ b/crowd/crowd.php
@@ -18,6 +18,8 @@ jimport('joomla.client.http');
  
 class plgAuthenticationCrowd extends JPlugin
 {
+	const LOGGER_CATEGORY = 'crowd';
+
     /**
      * Constructor
      *
@@ -30,9 +32,8 @@ class plgAuthenticationCrowd extends JPlugin
      */
     function plgAuthenticationCrowd(& $subject, $config) {
         parent::__construct($subject, $config);
-        JLog::addLogger(array('text_file' => 'debug.crowd.log'));
-        JLog::add('crowd 0.01 Start logging');
-        //JLog::add('crowd config params: ' . $this->params);
+        JLog::addLogger(array('text_file' => 'debug.crowd.log'), JLog::DEBUG, array(self::LOGGER_CATEGORY));
+        JLog::add('crowd 0.01 Start logging', JLog::DEBUG, self::LOGGER_CATEGORY);
     }
     
   // see rules.php
@@ -55,7 +56,7 @@ class plgAuthenticationCrowd extends JPlugin
   	JLog::add('check if we have to delete user ' . $credentials['username']);
   	$id = intval(JUserHelper::getUserId($credentials['username']));
   	if ($id < 1) {
-  		JLog::add('user not known to joomla, do nothing');
+  		JLog::add('user not known to joomla, do nothing', JLog::DEBUG, self::LOGGER_CATEGORY);
   		return; // no such user in joomla, nothing to do for us
   	}
   	
@@ -63,23 +64,23 @@ class plgAuthenticationCrowd extends JPlugin
     $server = $this->params->get('crowd_url');
     $appname = $this->params->get('crowd_app_name');
     $apppass = $this->params->get('crowd_password');
-    JLog::add('onUserAuthenticate: connecting to url ' . $server);
+    JLog::add('onUserAuthenticate: connecting to url ' . $server, JLog::DEBUG, self::LOGGER_CATEGORY);
     $authcode = base64_encode($appname . ":" . $apppass);
     // JLog::add('auth code [' . $authcode . ']');
 
     // request cookie config from crowd
     $request_url = $server . '/rest/usermanagement/1/user?username=' . $credentials['username'];
-    $request_header =  array('Accept' => 'application/json', 'Content-type' => 'application/xml',
+    $request_header =  array('Accept' => 'application/json', 'Content-Type' => 'application/xml',
                              'Authorization' => 'Basic ' . $authcode);
     $http = new JHttp;
-    JLog::add('request url ' . $request_url);
-    JLog::add('with headers ' . var_export($request_header, true));
+    JLog::add('request url ' . $request_url, JLog::DEBUG, self::LOGGER_CATEGORY);
+    JLog::add('with headers ' . var_export($request_header, true), JLog::DEBUG, self::LOGGER_CATEGORY);
     $result = $http->get($request_url, $request_header);
-  	JLog::add('response: ' . var_export($result, true));
+  	JLog::add('response: ' . var_export($result, true), JLog::DEBUG, self::LOGGER_CATEGORY);
   	$obj = json_decode($result->body);
-    JLog::add('msg: ' . $obj->reason);
+    JLog::add('msg: ' . $obj->reason, JLog::DEBUG, self::LOGGER_CATEGORY);
     if ($obj->reason != 'USER_NOT_FOUND') {
-    	JLog::add('crowd seems to know about this user, do not delete from joomla!');
+    	JLog::add('crowd seems to know about this user, do not delete from joomla!', JLog::DEBUG, self::LOGGER_CATEGORY);
     	return;
     }
   	
@@ -87,53 +88,53 @@ class plgAuthenticationCrowd extends JPlugin
     $user = JUser::getInstance();
     $user->load($id);
     $user->delete();
-    JLog::add('user deleted from joomla.');
+    JLog::add('user deleted from joomla.', JLog::DEBUG, self::LOGGER_CATEGORY);
   }
   
   /** creates a new joomla group, returns the resulting group id */
   protected function createGroup($gname)
   {
   	//$db = JFactory::getDbo();
-    JLog::add('createGroup not yet implemented!');
+    JLog::add('createGroup not yet implemented!', JLog::DEBUG, self::LOGGER_CATEGORY);
   }
 
     
     /** Trust the sso flag, login without password */
     function doSSOLogin( $credentials, $options, &$response )
     {
-	    JLog::add('crowd::onUserAuthenticate immediate login: ' . var_export($credentials, true));
+	    JLog::add('crowd::onUserAuthenticate immediate login: ' . var_export($credentials, true), JLog::DEBUG, self::LOGGER_CATEGORY);
 	    $response->status = JAuthentication::STATUS_SUCCESS;
 	    $response->email = $credentials['email'];
 	    $response->fullname = $credentials['fullname'];
 	    $response->username = $credentials['username'];
 	    $response->error_message = '';
-	    JLog::add('crowd: returning response: ' . var_export($response, true));
+	    JLog::add('crowd: returning response: ' . var_export($response, true), JLog::DEBUG, self::LOGGER_CATEGORY);
 	    return true;
     }
  
  		/** checks username/password against crowd */
     function doCrowdLogin( $credentials, $options, &$response )
     {
-      JLog::add('doing regular login');
+      JLog::add('doing regular login', JLog::DEBUG, self::LOGGER_CATEGORY);
 
       $server = $this->params->get('crowd_url');
       $appname = $this->params->get('crowd_app_name');
       $apppass = $this->params->get('crowd_password');
-      JLog::add('onUserAuthenticate: connecting to url ' . $server);
+      JLog::add('onUserAuthenticate: connecting to url ' . $server, JLog::DEBUG, self::LOGGER_CATEGORY);
       $authcode = base64_encode($appname . ":" . $apppass);
       // JLog::add('auth code [' . $authcode . ']');
 
       // request cookie config from crowd
       $request_url = $server . '/rest/usermanagement/1/config/cookie';
-      $request_header =  array('Accept' => 'application/json', 'Content-type' => 'application/xml',
+      $request_header =  array('Accept' => 'application/json', 'Content-Type' => 'application/xml',
                                'Authorization' => 'Basic ' . $authcode);
       $http = new JHttp;
-      JLog::add('request url ' . $request_url);
-      JLog::add('with headers ' . var_export($request_header, true));
+      JLog::add('request url ' . $request_url, JLog::DEBUG, self::LOGGER_CATEGORY);
+      JLog::add('with headers ' . var_export($request_header, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       $result = $http->get($request_url, $request_header);
-      JLog::add('cookie config: ' . var_export($result, true));
+      JLog::add('cookie config: ' . var_export($result, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       if (!$result or $result->code != 200) {
-        $response->status = JAUTHENTICATE_STATUS_FAILURE;
+        $response->status = JAuthentication::STATUS_FAILURE;
         $response->error_message = 'Cannot fetch cookie config from crowd';
         return false;
       }
@@ -147,11 +148,11 @@ class plgAuthenticationCrowd extends JPlugin
          $cookieDomain = $altCookieDomain;
       }
       
-      JLog::add('cookie name: ' . $cookieName . ', domain: ' . $cookieDomain);
+      JLog::add('cookie name: ' . $cookieName . ', domain: ' . $cookieDomain, JLog::DEBUG, self::LOGGER_CATEGORY);
 
       // now trying to login
       $request_url = $server . '/rest/usermanagement/1/session?validate-password=true';
-      JLog::add('request url ' . $request_url);
+      JLog::add('request url ' . $request_url, JLog::DEBUG, self::LOGGER_CATEGORY);
       $request_data = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' .
                       '<authentication-context>' .
                       '    <username>' . $credentials['username'] . '</username>' .
@@ -164,23 +165,23 @@ class plgAuthenticationCrowd extends JPlugin
                       '    </validation-factors>' .
                       '</authentication-context>';
       #JLog::add('request data: ' . $request_data);
-      $request_header =  array('Accept' => 'application/xml', 'Content-type' => 'application/xml',
+      $request_header =  array('Accept' => 'application/xml', 'Content-Type' => 'application/xml',
                                'Authorization' => 'Basic ' . $authcode);
-      JLog::add('with headers ' . var_export($request_header, true));
+      JLog::add('with headers ' . var_export($request_header, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       $result = $http->post($request_url, $request_data, $request_header);
-      JLog::add('response: ' . var_export($result, true));
+      JLog::add('response: ' . var_export($result, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       if (!$result or $result->code != 201) {
-        JLog::add('have not got expected code 201, login failed');
-        $response->status = JAUTHENTICATE_STATUS_FAILURE;
+        JLog::add('have not got expected code 201, login failed', JLog::DEBUG, self::LOGGER_CATEGORY);
+        $response->status = JAuthentication::STATUS_FAILURE;
         $response->error_message = 'Login to crowd failed';
         return false;
       }
-      JLog::add('fetching info from new location: ' . $result->headers['Location']);
+      JLog::add('fetching info from new location: ' . $result->headers['Location'], JLog::DEBUG, self::LOGGER_CATEGORY);
       $result = $http->get($result->headers['Location'], $request_header);
-      JLog::add('response: ' . var_export($result, true));
+      JLog::add('response: ' . var_export($result, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       if (!$result or $result->code != 200) {
-        JLog::add('have not got expected code 200, login failed');
-        $response->status = JAUTHENTICATE_STATUS_FAILURE;
+        JLog::add('have not got expected code 200, login failed', JLog::DEBUG, self::LOGGER_CATEGORY);
+        $response->status = JAuthentication::STATUS_FAILURE;
         $response->error_message = 'Login to crowd failed';
         return false;
       }
@@ -192,12 +193,12 @@ class plgAuthenticationCrowd extends JPlugin
       $response->email = (string) $xml->user->email;
       $response->fullname = (string) $xml->user->{'display-name'};
       $response->username = (string) $xml->user['name'];
-      $response->status = JAUTHENTICATE_STATUS_SUCCESS;
+      $response->status = JAuthentication::STATUS_SUCCESS;
       $response->error_message = '';
-      JLog::add('login successfull, returning: ' . var_export($response, true));
+      JLog::add('login successfull, returning: ' . var_export($response, true), JLog::DEBUG, self::LOGGER_CATEGORY);
 
       // finally export our token as cookie
-      JLog::add('set cookie ' . $cookieName . ' = ' . $token);
+      JLog::add('set cookie ' . $cookieName . ' = ' . $token, JLog::DEBUG, self::LOGGER_CATEGORY);
       setcookie($cookieName,$token, 0, "/", $cookieDomain,false,true);
 
       return true;
@@ -205,34 +206,34 @@ class plgAuthenticationCrowd extends JPlugin
     
     function handleGroups( $user, $credentials, $options, &$response ) 
     {
-    	JLog::add('login succeeded, obtaining groups');
+    	JLog::add('login succeeded, obtaining groups', JLog::DEBUG, self::LOGGER_CATEGORY);
       $server = $this->params->get('crowd_url');
       $appname = $this->params->get('crowd_app_name');
       $apppass = $this->params->get('crowd_password');
-      JLog::add('handleGroups: connecting to url ' . $server);
+      JLog::add('handleGroups: connecting to url ' . $server, JLog::DEBUG, self::LOGGER_CATEGORY);
       $authcode = base64_encode($appname . ":" . $apppass);
       // JLog::add('auth code [' . $authcode . ']');
 
       // request groups from crowd
       $request_url = $server . '/rest/usermanagement/1/user/group/direct?username=' . $credentials['username'];
-      $request_header =  array('Accept' => 'application/json', 'Content-type' => 'application/xml',
+      $request_header =  array('Accept' => 'application/json', 'Content-Type' => 'application/xml',
                                'Authorization' => 'Basic ' . $authcode);
       $http = new JHttp;
-      JLog::add('request url ' . $request_url);
-      JLog::add('with headers ' . var_export($request_header, true));
+      JLog::add('request url ' . $request_url, JLog::DEBUG, self::LOGGER_CATEGORY);
+      JLog::add('with headers ' . var_export($request_header, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       $result = $http->get($request_url, $request_header);
-      JLog::add('group config: ' . var_export($result, true));
+      JLog::add('group config: ' . var_export($result, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       if (!$result or $result->code != 200) {
-        $response->status = JAUTHENTICATE_STATUS_FAILURE;
+        $response->status = JAuthentication::STATUS_FAILURE;
         $response->error_message = 'Cannot fetch groups from crowd';
         return false;
       }
       $obj = json_decode($result->body);
       $groups = $obj->groups; // array containing all crowd groups of this user as objects with attr 'name'
-      JLog::add('crowd groups: ' . var_export($groups, true));
+      JLog::add('crowd groups: ' . var_export($groups, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       $response->groups = array();
       $allgroups = $this->getUserGroups(); // array of objects containing group name and joomla id as 'text' and 'value'
-      JLog::add('joomla groups: ' . var_export($allgroups, true));
+      JLog::add('joomla groups: ' . var_export($allgroups, true), JLog::DEBUG, self::LOGGER_CATEGORY);
       $allgroupnames = array(); // array of joomla group names
 
       $groupmapping = explode(";",$this->params->get('crowd_group_map'));
@@ -240,13 +241,13 @@ class plgAuthenticationCrowd extends JPlugin
       foreach ($groupmapping as $gm) {
       	$ml = explode(":",$gm);
       	if (count($ml) != 2 || intval($ml[1]) < 1) {
-      		JLog::add('ignored mapping entry [' . $gm . ']');
+      		JLog::add('ignored mapping entry [' . $gm . ']', JLog::DEBUG, self::LOGGER_CATEGORY);
       	}
       	else {
-      		$groupmap[trim($ml[0])] = intval($ml[1]);
+      		$groupmap[trim($ml[0])] = explode(",",$ml[1]);
       	}
       }  
-      JLog::add('groupmap: ' . var_export($groupmap,true));    
+      JLog::add('groupmap: ' . var_export($groupmap,true), JLog::DEBUG, self::LOGGER_CATEGORY);    
       
       foreach ($allgroups as $jgroup) {
       	array_push($allgroupnames, $jgroup->text);
@@ -255,25 +256,32 @@ class plgAuthenticationCrowd extends JPlugin
       // first remove user from all groups 
       foreach ($allgroups as $group) {
       	$res = JUserHelper::removeUserFromGroup($user->id, $group->value);
-      	JLog::add('removed user from group ' . $group->text . ' with result ' . $res);
+      	JLog::add('removed user from group ' . $group->text . ' with result ' . $res, JLog::DEBUG, self::LOGGER_CATEGORY);
       }
+	  
+	  // Process Group Map default if exists
+	  if (array_key_exists("*", $groupmap)) {
+        	$res = JUserHelper::setUserGroups($user->id, $groupmap["*"]);
+        	JLog::add('added user to mapped groups ' . $group->name . ':' . implode(",", $groupmap["*"]) . ' result: ' . $res, JLog::DEBUG, self::LOGGER_CATEGORY);		
+      }
+		
       
       // now re-add all groups we have got from crowd            
       foreach ($groups as $group) {
-      	JLog::add('got group: ' . $group->name);
+      	JLog::add('got group: ' . $group->name, JLog::DEBUG, self::LOGGER_CATEGORY);
       	array_push($response->groups, $group->name);
       	//array_push($user->groups, $group->name);
       	
         // check mapping
         if (array_key_exists($group->name, $groupmap)) {
-        	$res = JUserHelper::addUserToGroup($user->id, $groupmap[$group->name]);
-        	JLog::add('added user to mapped group ' . $group->name . ' result: ' . $res);
+        	$res = JUserHelper::setUserGroups($user->id, $groupmap[$group->name]);
+        	JLog::add('added user to mapped groups ' . $group->name . ':' . implode(",", $groupmap[$group->name]) . ' result: ' . $res, JLog::DEBUG, self::LOGGER_CATEGORY);
         	continue;
         }      	
       	
 	      // create new groups if needed 
 	      if (!in_array($group->name, $allgroupnames)) {
-	      	JLog::add('create new group ' . $group->name);
+	      	JLog::add('create new group ' . $group->name, JLog::DEBUG, self::LOGGER_CATEGORY);
 	      	$gid = $this->createGroup($group->name);
 	      }
 	      else { // group already exists in joomla
@@ -281,9 +289,9 @@ class plgAuthenticationCrowd extends JPlugin
 	      		if ($g->text == $group->name) {
               try {
 			      	  JUserHelper::addUserToGroup($user->id, $g->value);
-			      	  JLog::add("added user " . $user->id . ' to group ' . $g->name . ' id: ' . $g->value);
+			      	  JLog::add("added user " . $user->id . ' to group ' . $g->name . ' id: ' . $g->value, JLog::DEBUG, self::LOGGER_CATEGORY);
               } catch (Exception $e) {
-                JLog::add('adding user ' . $user->id . ' to group ' . $g->name . ' caused exception: ' . $e->getMessage());
+                JLog::add('adding user ' . $user->id . ' to group ' . $g->name . ' caused exception: ' . $e->getMessage(), JLog::DEBUG, self::LOGGER_CATEGORY);
               }
 	      	  }
 	      	}
@@ -292,7 +300,7 @@ class plgAuthenticationCrowd extends JPlugin
       try {
         $user->save();
       } catch (Exception $e) {
-        JLog::add('saving user ' . $user->id . ' caused exception: ' . $e->getMessage());
+        JLog::add('saving user ' . $user->id . ' caused exception: ' . $e->getMessage(), JLog::DEBUG, self::LOGGER_CATEGORY);
       }
 
     }
@@ -309,7 +317,7 @@ class plgAuthenticationCrowd extends JPlugin
      */
     function onUserAuthenticate( $credentials, $options, &$response )
     {
-      JLog::add('onUserAuthenticate: auth started');
+      JLog::add('onUserAuthenticate: auth started', JLog::DEBUG, self::LOGGER_CATEGORY);
       $response->type = 'Crowd';
       $response->password_clear = "";
       $login_succeeded = false;
@@ -320,7 +328,7 @@ class plgAuthenticationCrowd extends JPlugin
       	$login_succeeded = $this->doCrowdLogin($credentials, $options, $response);
       }
 	    if ($credentials['username'] == "admin") {
-        JLog::add('admin login, neither check user nor groups');
+        JLog::add('admin login, neither check user nor groups', JLog::DEBUG, self::LOGGER_CATEGORY);
         return login_succeeded; // do not more for admin user
       }
       if (! $login_succeeded) {
@@ -331,7 +339,7 @@ class plgAuthenticationCrowd extends JPlugin
       if ($id = intval(JUserHelper::getUserId($response->username))) {
       }
       else {
-      	JLog::add('creating new user ' . $response->username);
+      	JLog::add('creating new user ' . $response->username, JLog::DEBUG, self::LOGGER_CATEGORY);
       	$user->set('id', 0);
 				$user->set('name', $response->fullname);
 				$user->set('username', $response->username);

--- a/crowd/crowd.xml
+++ b/crowd/crowd.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<install version="1.5" type="plugin" group="authentication" method="upgrade">
+<extension version="1.5" type="plugin" group="authentication" method="upgrade">
     <name>Authentication - Crowd</name>
     <author>Joomla! Documentation Project</author>
     <creationDate>Apr 10, 2012</creationDate>
@@ -44,4 +44,4 @@
             </fieldset>
         </fields>
     </config>
-</install>
+</extension>

--- a/crowdsso/crowdsso.php
+++ b/crowdsso/crowdsso.php
@@ -37,6 +37,7 @@ class plgSystemCrowdSSO extends JPlugin {
 
     const CONFIG_DISABLEADMIN = 'disable_admin';
     const CONFIG_COOKIENAME = 'cookieName';
+	const LOGGER_CATEGORY = 'crowdsso';
 
     /**
      * @param object $subject The object to observe
@@ -44,8 +45,8 @@ class plgSystemCrowdSSO extends JPlugin {
      */
     public function plgSystemCrowdSSO(&$subject, $config) {
         parent::__construct($subject, $config);
-        JLog::addLogger(array('text_file' => 'debug.crowd.log'));
-        JLog::add('crowd sso 0.01 created');
+        JLog::addLogger(array('text_file' => 'debug.crowd.log'), JLog::DEBUG, array(self::LOGGER_CATEGORY));
+        JLog::add('crowd sso 0.01 created', JLog::DEBUG, self::LOGGER_CATEGORY);
     }
 
     /**
@@ -53,31 +54,31 @@ class plgSystemCrowdSSO extends JPlugin {
      * when the cookie is set/unset.
      */
     public function onAfterInitialise() {
-        JLog::add('crowd sso onAfterInitialise');
+        JLog::add('crowd sso onAfterInitialise', JLog::DEBUG, self::LOGGER_CATEGORY);
         if ((bool)$this->params->get(self::CONFIG_DISABLEADMIN) && JFactory::getApplication()->isAdmin()) {
             return; //No SSO for administrator section
         }
         $user = JFactory::getUser();
-        JLog::add("current user is: ". $user->username .", guest: " . (int)$user->guest . ", admin: " . JFactory::getApplication()->isAdmin());
+        JLog::add("current user is: ". $user->username .", guest: " . (int)$user->guest . ", admin: " . JFactory::getApplication()->isAdmin(), JLog::DEBUG, self::LOGGER_CATEGORY);
         $token = $this->_readToken();
         if ($user->guest and empty($token)) { # case 1
-          JLog::add('case 1: user is guest and crowd token is empty - thats fine, do nothing');
+          JLog::add('case 1: user is guest and crowd token is empty - thats fine, do nothing', JLog::DEBUG, self::LOGGER_CATEGORY);
           return;
         }
         else if ($user->guest and !empty($token)) { # case 2
-          JLog::add('case 2: user is guest and we have a crowd token - try sso login');
+          JLog::add('case 2: user is guest and we have a crowd token - try sso login', JLog::DEBUG, self::LOGGER_CATEGORY);
           $this->_tryLogin($token);
         }
         else if (!$user->guest and empty($token)) { # case 3
-          JLog::add('case 3: user is not guest, but crowd token is empty - thats bad, logout');
+          JLog::add('case 3: user is not guest, but crowd token is empty - thats bad, logout', JLog::DEBUG, self::LOGGER_CATEGORY);
           $this->_tryLogout($user);
         }
         else if (!$user->guest) { # case 4
-          JLog::add('case 4: user is not guest and we have a token - we do nothing');
+          JLog::add('case 4: user is not guest and we have a token - we do nothing', JLog::DEBUG, self::LOGGER_CATEGORY);
           return; # do nothing, we just keep her
         }
         else {
-          JLog::add('crowdsso::onAfterInitialise: unknown case, strange things going on here...');
+          JLog::add('crowdsso::onAfterInitialise: unknown case, strange things going on here...', JLog::DEBUG, self::LOGGER_CATEGORY);
         }
     }
 
@@ -96,13 +97,13 @@ class plgSystemCrowdSSO extends JPlugin {
       $apppass = $this->params->get('crowd_password');
       $authcode = base64_encode($appname . ":" . $apppass);
       $request_url = $server . '/rest/usermanagement/latest/session/' . $token;
-      $request_header = array('Accept' => 'application/json', 'Content-type' => 'application/xml', 
+      $request_header = array('Accept' => 'application/json', 'Content-Type' => 'application/xml', 
                               'Authorization' => 'Basic ' . $authcode);
       $http = new JHttp;
       $result = $http->get($request_url, $request_header);
-      JLog::add('crowdsso response: ' . $result->code . ', data: ' . $result->body);
+      JLog::add('crowdsso response: ' . $result->code . ', data: ' . $result->body, JLog::DEBUG, self::LOGGER_CATEGORY);
       if ($result->code != 200) {
-        JLog::add('crowdsso login failed');
+        JLog::add('crowdsso login failed', JLog::DEBUG, self::LOGGER_CATEGORY);
         return -1;
       }
       $obj = json_decode($result->body);
@@ -126,7 +127,17 @@ class plgSystemCrowdSSO extends JPlugin {
       JFactory::getApplication()->redirect('/');
     }
 
+	function onUserLogout($user, $options = array()) {
+	  $cookiename = $this->params->get(self::CONFIG_COOKIENAME);
+      $cookiekey = str_replace('.', '_', $cookiename); # joomla replaces this?
+	  if (isset($_COOKIE[$cookiekey])) {
+	    unset($_COOKIE[$cookiekey]);
+	    setcookie($cookiename, '', time() - 3600, '/');
+        JLog::add('crowdsso::onUserLogout - deleted cookie ' . $cookiename, JLog::DEBUG, self::LOGGER_CATEGORY); 
+	  }
+	}
+
     function onUserLoginFailure($response) {
-      JLog::add('crowdsso::onUserLoginFailure for ' . $response['username'] . ' . because: ' . $response['error_message']);
+      JLog::add('crowdsso::onUserLoginFailure for ' . $response['username'] . ' . because: ' . $response['error_message'], JLog::DEBUG, self::LOGGER_CATEGORY);
     }
 }


### PR DESCRIPTION
This PR has the following

- Fixes for Joomla 3.x
- Refining of logging
- Group map supports multiple Joomla Group IDs (comma separated). Backwards compatible as explore will create an array with one item for existing case.
- Group map supports a default group list e.g. "*": 2;